### PR TITLE
fix: prevent timer from going into negative numbers

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,3 +35,29 @@ function startTimer() {
 
   }, 1000);
 }
+function startTimer() {
+  clearInterval(interval);
+
+  interval = setInterval(() => {
+    if (time <= 0) {
+      clearInterval(interval);
+      document.getElementById("timer").innerText = "00:00";
+
+      // play alarm (if you added earlier)
+      if (typeof alarmSound !== "undefined") {
+        alarmSound.play();
+      }
+
+      return;
+    }
+
+    time--;
+
+    let min = Math.floor(time / 60);
+    let sec = time % 60;
+
+    document.getElementById("timer").innerText =
+      `${min}:${sec < 10 ? "0" : ""}${sec}`;
+
+  }, 1000);
+}


### PR DESCRIPTION
Fixed bug where timer continued into negative values.

- Added condition to stop timer at 0
- Clears interval when time reaches zero
- Ensures UI displays 00:00 correctly
- Optional alarm trigger added

Closes #13