### PR TITLE
Add dark mode transition delay

### DIFF
--- a/style.css
+++ b/style.css
@@ -56,3 +56,6 @@ button:hover {
 .dark .card {
   background: #1e1e1e;
 }
+body, .card {
+  transition: background-color 0.9s ease, color 0.9s ease;
+}


### PR DESCRIPTION
 ## Smooth Dark Mode Transition
This PR enhances the Dark Mode experience by adding a CSS transition to the body and .card selectors. Instead of colors snapping instantly, background and text colors now fade gracefully over 0.9 seconds, creating a more polished and visually pleasing effect.
### Changes:
- Added transition property to body and .card
- Duration set to 0.9s for a smoother, more elegant fade
### Why:
- Improves user experience by reducing abrupt visual changes
- Adds a touch of refinement and modern feel to the UI

This pr closes #3
