### PR TITLE
Fix card fixed width issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,10 +15,12 @@ h1 {
   background: white;
   margin: 20px auto;
   padding: 20px;
-  width: 320px;
+  width: 90%;          /* Added for responsiveness */
+  max-width: 320px;    /* Prevents it from getting too wide */
   border-radius: 15px;
   box-shadow: 0 8px 20px rgba(0,0,0,0.2);
   transition: transform 0.2s;
+  box-sizing: border-box; /* Ensures padding doesn't break the width */
 }
 
 .card:hover {


### PR DESCRIPTION
### Description:

The .card class had a fixed width, which means it won't shrink on smaller mobile screens. 

***Solution***

Replace width: 320px; with width: 90%; and max-width: 320px; so it stays centered but flexes on small devices.

***Screenshots***
<img width=50% alt="127 0 0 1_5500_" src="https://github.com/user-attachments/assets/16dc63dc-bfc2-4b49-9abf-0cd485742645" />
<img width=50% alt="127 0 0 1_5500_ (1)" src="https://github.com/user-attachments/assets/9e15a291-436c-4c15-b6bf-1d130ebdc8e1" />

This PR 
Fixes #1 