### PR TITLE
Fix textarea breaking card layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,6 +33,12 @@ input, textarea {
   margin: 10px 0;
   border-radius: 8px;
   border: 1px solid #ccc;
+  box-sizing: border-box;
+}
+
+textarea {
+  resize: vertical; /* Prevents horizontal stretching */
+  min-height: 60px; 
 }
 
 button {


### PR DESCRIPTION
### Description:
This PR fixes a layout bug where the "Today's Goal" textarea could be dragged and stretched horizontally beyond the boundaries of its parent card container. 

### Changes made:
* Added `resize: vertical;` specifically to the `textarea` element in `style.css` so users can only stretch it up and down.
* Added `box-sizing: border-box;` to the inputs and textarea to ensure padding is calculated securely within the width constraints.
* Added a `min-height: 60px;` to give the textarea a comfortable starting size.

### Related Issue(s):
Closes #4

### Screenshots 
<img width=60% alt="image" src="https://github.com/user-attachments/assets/b0c474eb-e2cb-4e2e-b8bc-d65be6683711" />
